### PR TITLE
PID file; Heal schema changes for incremental imports

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,10 @@
 PATH
   remote: .
   specs:
-    postgres_to_redshift (0.3.0)
+    postgres_to_redshift (0.4.0)
       aws-sdk-v1 (~> 1.54)
       pg (>= 0.18.1)
+      pidfile
 
 GEM
   remote: https://rubygems.org/
@@ -22,6 +23,7 @@ GEM
     parser (2.6.2.0)
       ast (~> 2.4.0)
     pg (1.1.4)
+    pidfile (0.3.0)
     psych (3.1.0)
     rainbow (3.0.0)
     rake (10.4.2)

--- a/lib/postgres_to_redshift.rb
+++ b/lib/postgres_to_redshift.rb
@@ -9,6 +9,7 @@ require 'postgres_to_redshift/column'
 require 'postgres_to_redshift/copy_import'
 require 'postgres_to_redshift/full_import'
 require 'postgres_to_redshift/incremental_import'
+require 'postgres_to_redshift/tables'
 require 'postgres_to_redshift/update_tables'
 require 'postgres_to_redshift/version'
 

--- a/lib/postgres_to_redshift.rb
+++ b/lib/postgres_to_redshift.rb
@@ -1,9 +1,10 @@
-require 'pg'
-require 'uri'
 require 'aws-sdk-v1'
-require 'zlib'
+require 'pg'
+require 'pidfile'
 require 'tempfile'
 require 'time'
+require 'uri'
+require 'zlib'
 require 'postgres_to_redshift/table'
 require 'postgres_to_redshift/column'
 require 'postgres_to_redshift/copy_import'
@@ -18,6 +19,8 @@ module PostgresToRedshift
   extend self
 
   def update_tables
+    PidFile.new
+
     update_tables = UpdateTables.new(bucket: bucket, source_uri: source_uri, target_uri: target_uri, schema: schema)
     incremental? ? update_tables.incremental : update_tables.full
   end

--- a/lib/postgres_to_redshift/table.rb
+++ b/lib/postgres_to_redshift/table.rb
@@ -1,9 +1,8 @@
 module PostgresToRedshift
   class Table
-    attr_reader :columns, :attributes
-
     def initialize(attributes:, columns: [])
       @attributes = attributes
+      @dirty = false
       self.columns = columns
     end
 
@@ -39,5 +38,21 @@ module PostgresToRedshift
     def view?
       attributes['table_type'] == 'VIEW'
     end
+
+    def ==(other)
+      name == other.name && column_names == other.column_names
+    end
+
+    def dirty!
+      @dirty = true
+    end
+
+    def dirty?
+      dirty
+    end
+
+    private
+
+    attr_reader :columns, :attributes, :dirty
   end
 end

--- a/lib/postgres_to_redshift/tables.rb
+++ b/lib/postgres_to_redshift/tables.rb
@@ -1,0 +1,45 @@
+module PostgresToRedshift
+  class Tables
+    def initialize(source_connection:, target_connection:)
+      @source_connection = source_connection
+      @target_connection = target_connection
+    end
+
+    def all
+      source_tables = self.class.fetch_tables(connection: source_connection)
+      target_tables = self.class.fetch_tables(connection: target_connection)
+      source_tables.reject { |source_table| target_tables.include?(source_table) }.map(&:dirty!)
+      source_tables
+    end
+
+    class << self
+      def column_definitions(connection:, table_name:)
+        connection.exec("SELECT * FROM information_schema.columns WHERE table_schema='public' AND table_name='#{table_name}' ORDER BY ordinal_position")
+      end
+
+      def redshift_include_tables
+        @redshift_include_tables ||= ENV['REDSHIFT_INCLUDE_TABLES'].split(',')
+      end
+
+      def tables_sql
+        sql = "SELECT * FROM information_schema.tables WHERE table_schema = 'public' AND table_type in ('BASE TABLE', 'VIEW') AND table_name !~* '^pg_.*'"
+        if ENV['REDSHIFT_INCLUDE_TABLES']
+          table_names = "'" + redshift_include_tables.join("', '") + "'"
+          sql += " AND table_name IN (#{table_names})"
+        end
+        sql += ' ORDER BY table_name'
+        sql
+      end
+
+      def fetch_tables(connection:)
+        connection.exec(tables_sql).map do |table_attributes|
+          Table.new(attributes: table_attributes).tap do |table|
+            table.columns = column_definitions(connection: connection, table_name: table.name)
+          end
+        end
+      end
+    end
+
+    attr_reader :source_connection, :target_connection
+  end
+end

--- a/lib/postgres_to_redshift/version.rb
+++ b/lib/postgres_to_redshift/version.rb
@@ -1,3 +1,3 @@
 module PostgresToRedshift
-  VERSION = '0.3.0'.freeze
+  VERSION = '0.4.0'.freeze
 end

--- a/postgres_to_redshift.gemspec
+++ b/postgres_to_redshift.gemspec
@@ -22,4 +22,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rubocop', '~> 0.66'
   spec.add_dependency 'aws-sdk-v1', '~> 1.54'
   spec.add_dependency 'pg', '>= 0.18.1'
+  spec.add_dependency 'pidfile'
 end


### PR DESCRIPTION
- Adds a PID file to prevent two instances from running concurrently cc/ @mijoharas 
- Detects when schemas have diverged when running an incremental import and triggers a full import for the affected tables