### PR TITLE
Async uploads; Add timestamps to log messages

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    postgres_to_redshift (0.4.0)
+    postgres_to_redshift (0.4.1)
       aws-sdk-v1 (~> 1.54)
       pg (>= 0.18.1)
       pidfile
@@ -17,7 +17,7 @@ GEM
     jaro_winkler (1.5.2)
     json (1.8.6)
     mini_portile2 (2.4.0)
-    nokogiri (1.10.2)
+    nokogiri (1.10.3)
       mini_portile2 (~> 2.4.0)
     parallel (1.15.0)
     parser (2.6.2.0)

--- a/lib/postgres_to_redshift/copy_import.rb
+++ b/lib/postgres_to_redshift/copy_import.rb
@@ -62,7 +62,7 @@ module PostgresToRedshift
       chunk = 1
       bucket.objects.with_prefix("export/#{table.target_table_name}.psv.gz").delete_all
       begin
-        puts "Downloading #{table} changes between #{incremental_from} and #{incremental_to} at #{Time.now.utc}"
+        puts "#{Time.now.utc} - Downloading #{table} changes between #{incremental_from} and #{incremental_to}"
         copy_command = "COPY (#{select_sql}) TO STDOUT WITH DELIMITER '|'"
 
         source_connection.copy_data(copy_command) do
@@ -83,8 +83,9 @@ module PostgresToRedshift
     end
 
     def upload_table(buffer, chunk)
-      puts "Uploading #{table.target_table_name}.#{chunk}"
+      puts "#{Time.now.utc} - Uploading #{table.target_table_name}.#{chunk}"
       bucket.objects["export/#{table.target_table_name}.psv.gz.#{chunk}"].write(buffer)
+      puts "#{Time.now.utc} - Uploading #{table.target_table_name}.#{chunk} complete."
     end
 
     def import_table

--- a/lib/postgres_to_redshift/full_import.rb
+++ b/lib/postgres_to_redshift/full_import.rb
@@ -7,7 +7,7 @@ module PostgresToRedshift
     end
 
     def run
-      puts "Importing #{table.target_table_name} at #{Time.now.utc}"
+      puts "#{Time.now.utc} - Importing #{table.target_table_name}"
 
       # TRUNCATE cannot be rolled back
       target_connection.exec("DROP TABLE IF EXISTS #{table_name};")

--- a/lib/postgres_to_redshift/incremental_import.rb
+++ b/lib/postgres_to_redshift/incremental_import.rb
@@ -7,7 +7,7 @@ module PostgresToRedshift
     end
 
     def run
-      puts "Importing #{table.target_table_name} at #{Time.now.utc}"
+      puts "#{Time.now.utc} - Importing #{table.target_table_name}"
 
       target_connection.exec("CREATE TABLE IF NOT EXISTS #{table_name} (#{table.columns_for_create});")
 

--- a/lib/postgres_to_redshift/update_tables.rb
+++ b/lib/postgres_to_redshift/update_tables.rb
@@ -68,7 +68,7 @@ module PostgresToRedshift
       begin
         yield
       rescue StandardError => e
-        puts "Import failed with #{retries_remaining} retries remaining due to: #{e.message}"
+        puts "#{Time.now.utc} - Import failed with #{retries_remaining} retries remaining due to: #{e.message}"
         disconnect
         raise unless retries_remaining.positive?
 
@@ -80,7 +80,7 @@ module PostgresToRedshift
 
     def with_tracking
       start_time = Time.now.utc
-      puts "Import started at #{start_time}"
+      puts "#{Time.now.utc} - Import started"
       yield start_time
       File.write(PostgresToRedshift::TIMESTAMP_FILE_NAME, start_time.iso8601)
     end
@@ -93,7 +93,7 @@ module PostgresToRedshift
         puts 'Rolled back'
       else
         target_connection.exec('COMMIT;')
-        puts 'Committed'
+        puts "#{Time.now.utc} - Committed"
       end
     end
 


### PR DESCRIPTION
Speedup the import process by allowing the previous chunk to upload in parallel while the current chunk is being built.

Have also changed to logging to print timestamps to aid in identifying bottlenecks. 