### PR TITLE
Support not-null constraints

### DIFF
--- a/lib/postgres_to_redshift/column.rb
+++ b/lib/postgres_to_redshift/column.rb
@@ -32,6 +32,10 @@ module PostgresToRedshift
       attributes['data_type']
     end
 
+    def not_null?
+      attributes['is_nullable'].to_s.downcase == 'no'
+    end
+
     def data_type_for_copy
       CAST_TYPES_FOR_COPY[data_type] || data_type
     end

--- a/lib/postgres_to_redshift/table.rb
+++ b/lib/postgres_to_redshift/table.rb
@@ -23,7 +23,9 @@ module PostgresToRedshift
 
     def columns_for_create
       columns.map do |column|
-        %("#{column.name}" #{column.data_type_for_copy})
+        sql = %("#{column.name}" #{column.data_type_for_copy})
+        sql += " NOT NULL" if column.not_null?
+        sql
       end.join(', ')
     end
 


### PR DESCRIPTION
These are required for primary keys, which we want to add to redshift to help guide the redshift query planner. 

I have tested this with chat flow roots, but doing a full import. After that I created the primary key on the table as test.