### PR TITLE
Handle numeric data with varying scale/precision

### DIFF
--- a/lib/postgres_to_redshift/column.rb
+++ b/lib/postgres_to_redshift/column.rb
@@ -6,7 +6,7 @@ module PostgresToRedshift
       'jsonb' => 'CHARACTER VARYING(65535)',
       'bytea' => 'CHARACTER VARYING(65535)',
       'money' => 'DECIMAL(19,2)',
-      'numeric' => 'DECIMAL(19,2)',
+      'numeric' => 'DECIMAL',
       'oid' => 'CHARACTER VARYING(65535)',
       'ARRAY' => 'CHARACTER VARYING(65535)',
       'USER-DEFINED' => 'CHARACTER VARYING(65535)',
@@ -33,17 +33,37 @@ module PostgresToRedshift
       attributes['data_type']
     end
 
+    def numeric_scale
+      attributes['numeric_scale']
+    end
+
+    def numeric_precision
+      attributes['numeric_precision']
+    end
+
     def not_null?
       attributes['is_nullable'].to_s.downcase == 'no'
     end
 
     def data_type_for_copy
-      CAST_TYPES_FOR_COPY[data_type] || data_type
+      type = CAST_TYPES_FOR_COPY[data_type] || data_type
+      handle_additional_type_attributes(type)
     end
 
     private
 
     attr_reader :attributes
+
+    def handle_additional_type_attributes(type)
+      case type
+      when 'DECIMAL'
+        return type unless numeric_precision && numeric_scale
+
+        "#{type}(#{numeric_precision},#{numeric_scale})"
+      else
+        type
+      end
+    end
 
     def needs_type_cast?
       data_type != data_type_for_copy

--- a/lib/postgres_to_redshift/version.rb
+++ b/lib/postgres_to_redshift/version.rb
@@ -1,3 +1,3 @@
 module PostgresToRedshift
-  VERSION = '0.6.0'.freeze
+  VERSION = '0.6.1'.freeze
 end


### PR DESCRIPTION
We can't force all of our numeric fields into (19,2) instead we should
preserve the scale and precision we have in postgres.