### PR TITLE
Give a default precision,scale to numeric columns and round the values.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    postgres_to_redshift (0.5.0)
+    postgres_to_redshift (0.6.1)
       aws-sdk-v1 (~> 1.54)
       pg (>= 0.18.1)
       pidfile
@@ -19,7 +19,7 @@ GEM
     json (1.8.6)
     method_source (0.9.2)
     mini_portile2 (2.4.0)
-    nokogiri (1.10.4)
+    nokogiri (1.10.7)
       mini_portile2 (~> 2.4.0)
     parallel (1.15.0)
     parser (2.6.2.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    postgres_to_redshift (0.6.1)
+    postgres_to_redshift (0.6.2)
       aws-sdk-v1 (~> 1.54)
       pg (>= 0.18.1)
       pidfile

--- a/lib/postgres_to_redshift/version.rb
+++ b/lib/postgres_to_redshift/version.rb
@@ -1,3 +1,3 @@
 module PostgresToRedshift
-  VERSION = '0.6.1'.freeze
+  VERSION = '0.6.2'.freeze
 end


### PR DESCRIPTION
SQL produced for the accounts table is:

```sql
SELECT 
  "id", 
  "login_id", 
  "currency_code", 
  ROUND(CAST("balance" AS numeric(19,2)), 2) AS balance, 
  "name", 
  CAST("extra" AS CHARACTER VARYING(65535)) AS extra, 
  "nature", 
  "created_at", 
  "updated_at", 
  "account_id", 
  CAST("uuid" AS CHARACTER VARYING(36)) AS uuid, 
  "disconnected", 
  "chosen_name", 
  "deleted_time", 
  "linked_to_mangopay", 
  CAST("account_sort_code_digest" AS CHARACTER VARYING(65535)) AS account_sort_code_digest 
FROM accounts 
WHERE updated_at BETWEEN '1970-01-01T00:00:00Z' AND '2019-12-12T17:40:38Z'
```

Tested in the follower and it worked.