### PR TITLE
Limit number of digits to comply with precision.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    postgres_to_redshift (0.6.2)
+    postgres_to_redshift (0.6.3)
       aws-sdk-v1 (~> 1.54)
       pg (>= 0.18.1)
       pidfile

--- a/lib/postgres_to_redshift/column.rb
+++ b/lib/postgres_to_redshift/column.rb
@@ -1,6 +1,6 @@
 module PostgresToRedshift
   class Column
-    DEFAULT_PRECISION = 19
+    DEFAULT_PRECISION = 19 # 99_999_999_999_999_999.99
     DEFAULT_SCALE = 2
 
     CAST_TYPES_FOR_COPY = {
@@ -27,9 +27,10 @@ module PostgresToRedshift
       if needs_type_cast?
         case data_type
         when 'numeric'
+          precision = (numeric_precision || DEFAULT_PRECISION) + 1 # number of digits + the dot
           scale = numeric_scale || DEFAULT_SCALE
 
-          %[ROUND(CAST("#{name}" AS #{data_type_for_copy}), #{scale}) AS #{name}]
+          %[CAST(RIGHT(ROUND("#{name}", #{scale})::text, #{precision}) AS #{data_type_for_copy}) AS #{name}]
         else
           %[CAST("#{name}" AS #{data_type_for_copy}) AS #{name}]
         end

--- a/lib/postgres_to_redshift/version.rb
+++ b/lib/postgres_to_redshift/version.rb
@@ -1,3 +1,3 @@
 module PostgresToRedshift
-  VERSION = '0.6.2'.freeze
+  VERSION = '0.6.3'.freeze
 end


### PR DESCRIPTION
The problem we're trying to solve here is when a number has more digits than its numeric precision allows. 

We're converting the rounded number to text, and then picking a limited number of characters from the right, then casting to numeric again. 

Doesn't make me super happy, but it's a high-value/low-effort solution.