### PR TITLE
Ability to optimise database for joins with specified table

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    postgres_to_redshift (0.6.4)
+    postgres_to_redshift (0.7.0)
       aws-sdk-v1 (~> 1.54)
       pg (>= 0.18.1)
       pidfile

--- a/README.md
+++ b/README.md
@@ -76,8 +76,7 @@ For an _incremental_ import, the entire import process is performed in one datab
 Many of the options specified in the Redshift [docs](https://docs.aws.amazon.com/redshift/latest/dg/t_Creating_tables.html) are implemented.
 
 - By default, PK and FK constraints are applied wherever possible in Redshift automatically.
-- [Key distribution](https://docs.aws.amazon.com/redshift/latest/dg/t_Distributing_data.html) can be specified using the `POSTGRES_TO_REDSHIFT_DISTRIBUTION_KEY` env, which will use the specified column as a distkey for any table containing that column.
-- [Compound sort keys](https://docs.aws.amazon.com/redshift/latest/dg/t_Sorting_data.html) can be specified using the `POSTGRES_TO_REDSHIFT_SORT_KEYS` env (comma separated list), which will use the specified column(s) as the sort keys for any table containing one or more of those columns.
+- [Key distribution](https://docs.aws.amazon.com/redshift/latest/dg/t_Distributing_data.html) and [compound sort keys](https://docs.aws.amazon.com/redshift/latest/dg/t_Sorting_data.html) will be defined if possible, based on the table's primary key. If table structure is meant to be optimised for the table specified in the `POSTGRES_TO_REDSHIFT_OPTIMISED_FOR_TABLE` env, then any tables with a foreign key to the optimised table will be distributed and sorted based on this foreign key column instead.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -71,6 +71,14 @@ An import will be attempted three times before giving up and raising the excepti
 
 For an _incremental_ import, the entire import process is performed in one database transaction to ensure that the data remains in a consistent state while the import is running as it is assumed that the incremental import will be running during business hours moving a relatively small amount of data. For a _full_ import, each table is imported in its own transaction as it is assumed that the full import is running outside of business hours and would be moving too large a volume of data to be performed in a single transaction.
 
+### Performance tuning
+
+Many of the options specified in the Redshift [docs](https://docs.aws.amazon.com/redshift/latest/dg/t_Creating_tables.html) are implemented.
+
+- By default, PK and FK constraints are applied wherever possible in Redshift automatically.
+- [Key distribution](https://docs.aws.amazon.com/redshift/latest/dg/t_Distributing_data.html) can be specified using the `POSTGRES_TO_REDSHIFT_DISTRIBUTION_KEY` env, which will use the specified column as a distkey for any table containing that column.
+- [Compound sort keys](https://docs.aws.amazon.com/redshift/latest/dg/t_Sorting_data.html) can be specified using the `POSTGRES_TO_REDSHIFT_SORT_KEYS` env (comma separated list), which will use the specified column(s) as the sort keys for any table containing one or more of those columns.
+
 ## Contributing
 
 1. Fork it ( https://github.com/kitchensurfing/postgres_to_redshift/fork )

--- a/lib/postgres_to_redshift.rb
+++ b/lib/postgres_to_redshift.rb
@@ -13,6 +13,7 @@ require 'postgres_to_redshift/incremental_import'
 require 'postgres_to_redshift/key'
 require 'postgres_to_redshift/keys'
 require 'postgres_to_redshift/tables'
+require 'postgres_to_redshift/tuning'
 require 'postgres_to_redshift/update_tables'
 require 'postgres_to_redshift/version'
 

--- a/lib/postgres_to_redshift/copy_import.rb
+++ b/lib/postgres_to_redshift/copy_import.rb
@@ -95,7 +95,7 @@ module PostgresToRedshift
 
     def import_table
       args = { table: table, target_connection: target_connection, schema: schema }
-      import = incremental? ? IncrementalImport.new(**args) : FullImport.new(**args)
+      import = incremental? ? IncrementalImport.new(**args) : FullImport.new(**args.merge(source_connection: source_connection))
       import.run
     end
 

--- a/lib/postgres_to_redshift/full_import.rb
+++ b/lib/postgres_to_redshift/full_import.rb
@@ -12,7 +12,8 @@ module PostgresToRedshift
       # TRUNCATE cannot be rolled back
       target_connection.exec("DROP TABLE IF EXISTS #{table_name} CASCADE;")
 
-      target_connection.exec("CREATE TABLE #{table_name} (#{table.columns_for_create});")
+      puts "#{Time.now.utc} - Creating #{table.target_table_name} with:\n#{create_table_statement}"
+      target_connection.exec("#{create_table_statement};")
 
       target_connection.exec("COPY #{table_name} FROM 's3://#{ENV['S3_DATABASE_EXPORT_BUCKET']}/export/#{table.target_table_name}.psv.gz' CREDENTIALS 'aws_access_key_id=#{ENV['S3_DATABASE_EXPORT_ID']};aws_secret_access_key=#{ENV['S3_DATABASE_EXPORT_KEY']}' GZIP TRUNCATECOLUMNS ESCAPE DELIMITER as '|';")
 
@@ -23,6 +24,43 @@ module PostgresToRedshift
 
     def table_name
       "#{schema}.#{target_connection.quote_ident(table.target_table_name)}"
+    end
+
+    def create_table_statement
+      statement = "CREATE TABLE #{table_name} (#{table.columns_for_create})"
+      statement += " DISTSTYLE KEY DISTKEY (#{distribution_key})" if distribution_key.present?
+      statement += " SORTKEY(#{sort_keys.first})" if sort_keys.one?
+      statement += " COMPOUND SORTKEY(#{sort_keys.join(',')})" if sort_keys.count > 1
+      statement
+    end
+
+    def key_is_primary_for_table?(key)
+      table.target_table_name.downcase == key.chomp('_id') + 's'
+    end
+
+    def table_includes_column?(column)
+      table.column_names.map(&:downcase).include?(column)
+    end
+
+    def distribution_key
+      distkey = ENV['POSTGRES_TO_REDSHIFT_DISTRIBUTION_KEY']&.downcase&.strip
+      return if distkey.empty?
+
+      distkey = 'id' if key_is_primary_for_table?(distkey)
+      distkey if table_includes_column?(distkey)
+    end
+
+    def sort_keys
+      sortkeys = ENV['POSTGRES_TO_REDSHIFT_SORT_KEYS']&.split(',')&.map(&:strip)&.map(&:downcase) || []
+      sortkeys.map do |sortkey|
+        if key_is_primary_for_table?(sortkey)
+          'id'
+        else
+          sortkey
+        end
+      end.select do |sortkey|
+        table_includes_column?(sortkey)
+      end
     end
 
     attr_reader :table, :target_connection, :schema

--- a/lib/postgres_to_redshift/key.rb
+++ b/lib/postgres_to_redshift/key.rb
@@ -2,6 +2,8 @@ module PostgresToRedshift
   class Key
     PRIMARY_KEY = 'p'.freeze
     FOREIGN_KEY = 'f'.freeze
+    PRIMARY_KEY_DECOMPOSER = /PRIMARY KEY \((?<source_column_name>\w+)\)/i
+    FOREIGN_KEY_DECOMPOSER = /FOREIGN KEY \((?<source_column_name>\w+)\) REFERENCES (?<target_table_name>\w+)\((?<target_column_name>\w+)\)/i
 
     def initialize(attributes:)
       @attributes = attributes
@@ -18,9 +20,42 @@ module PostgresToRedshift
       end
     end
 
+    def primary?
+      key_type == PRIMARY_KEY
+    end
+
+    def source_column_name
+      decomposed_key[:source_column_name]
+    end
+
+    def target_table_name
+      return if primary?
+
+      decomposed_key[:target_table_name]
+    end
+
+    def target_column_name
+      return if primary?
+
+      decomposed_key[:target_column_name]
+    end
+
     private
 
     attr_reader :attributes
+
+    def decomposed_key
+      regex = case key_type
+              when PRIMARY_KEY
+                PRIMARY_KEY_DECOMPOSER
+              when FOREIGN_KEY
+                FOREIGN_KEY_DECOMPOSER
+              else
+                raise "Unsupported key type #{key_type}"
+              end
+
+      regex.match(key_definition)
+    end
 
     def key_definition
       attributes['key_definition']

--- a/lib/postgres_to_redshift/tuning.rb
+++ b/lib/postgres_to_redshift/tuning.rb
@@ -1,0 +1,60 @@
+module PostgresToRedshift
+  class Tuning
+    DEFAULT_SORT_KEYS = %w[created_at] # We often filter and sort by these columns
+
+    def initialize(table:, source_connection:)
+      @table = table
+      @table_name = table.target_table_name.downcase
+      @optimised_for_table_name = ENV['POSTGRES_TO_REDSHIFT_OPTIMISED_FOR_TABLE']&.downcase&.strip || table_name
+      @keys = Keys.new(source_connection: source_connection, tables: [table_name, optimised_for_table_name].uniq).all
+    end
+
+    # If there is a reference to the optimised table, sort on this column in order to optimise any join with optimised table
+    # Else, sort by PK to optimise any joins or filter on this table
+    def sort_keys
+      sort_key_column_names = if can_optimise_for_different_table?
+                           [foreign_key_column_name_to_optimised_table]
+                         else
+                           [primary_key_column_name].compact
+                         end
+
+      sort_key_column_names + DEFAULT_SORT_KEYS.select { |column_name| table_includes_column?(column_name) }
+    end
+
+    # If there is a reference to the optimised table, distribute by this column in order to optimise any join with optimised table
+    # Else, distribute by PK to optimise any joins or filter on this table
+    def distribution_key
+      return foreign_key_column_name_to_optimised_table if can_optimise_for_different_table?
+
+      primary_key_column_name
+    end
+
+    private
+
+    def table_includes_column?(column_name)
+      table.column_names.map(&:downcase).include?(column_name)
+    end
+
+    def can_optimise_for_different_table?
+      optimised_for_different_table? && foreign_keys_to_optimised_table.any?
+    end
+
+    def optimised_for_different_table?
+      optimised_for_table_name != table_name
+    end
+
+    def primary_key_column_name
+      keys.detect(&:primary?)&.source_column_name
+    end
+
+    def foreign_key_column_name_to_optimised_table
+      foreign_keys_to_optimised_table.first&.source_column_name
+    end
+
+    def foreign_keys_to_optimised_table
+      keys.reject(&:primary?).select { |key| key.target_table_name.downcase == optimised_for_table_name }
+    end
+
+    attr_reader :keys, :optimised_for_table_name, :table_name, :table
+  end
+end

--- a/lib/postgres_to_redshift/version.rb
+++ b/lib/postgres_to_redshift/version.rb
@@ -1,3 +1,3 @@
 module PostgresToRedshift
-  VERSION = '0.6.5'.freeze
+  VERSION = '0.7.0'.freeze
 end


### PR DESCRIPTION
[Key distribution](https://docs.aws.amazon.com/redshift/latest/dg/t_Distributing_data.html) and [compound sort keys](https://docs.aws.amazon.com/redshift/latest/dg/t_Sorting_data.html) will be now defined if possible, based on the table's primary key. If table structure is meant to be optimised for the table specified in the `POSTGRES_TO_REDSHIFT_OPTIMISED_FOR_TABLE` env, then any tables with a foreign key to the optimised table will be distributed and sorted based on this foreign key column instead. From the Redshift docs:

> Data redistribution can account for a substantial portion of the cost of a query plan, and the network traffic it generates can affect other database operations and slow overall system performance. To the extent that you anticipate where best to locate data initially, you can minimize the impact of data redistribution. 

and

> Compound sort keys might speed up joins, GROUP BY and ORDER BY operations, and window functions that use PARTITION BY and ORDER BY. For example, a merge join, which is often faster than a hash join, is feasible when the data is distributed and presorted on the joining columns. Compound sort keys also help improve compression. 

This has resulted in a optimiser cost reduction from 636,277,384,734 to 80,254,851,584 for our WAU query.

