### PR TITLE
Recreate keys for dirty tables after incremental import

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    postgres_to_redshift (0.7.0)
+    postgres_to_redshift (0.7.1)
       aws-sdk-v1 (~> 1.54)
       pg (>= 0.18.1)
       pidfile
@@ -24,7 +24,7 @@ GEM
     parallel (1.15.0)
     parser (2.6.2.0)
       ast (~> 2.4.0)
-    pg (1.1.4)
+    pg (1.2.1)
     pidfile (0.3.0)
     pry (0.12.2)
       coderay (~> 1.1.0)

--- a/lib/postgres_to_redshift/incremental_import.rb
+++ b/lib/postgres_to_redshift/incremental_import.rb
@@ -18,6 +18,7 @@ module PostgresToRedshift
       target_connection.exec("DELETE FROM #{table_name} USING #{temp_table_name} source WHERE #{table_name}.id = source.id;")
 
       target_connection.exec("INSERT INTO #{table_name} SELECT * FROM #{temp_table_name};")
+      target_connection.exec("DROP TABLE #{temp_table_name};")
     end
 
     private

--- a/lib/postgres_to_redshift/key.rb
+++ b/lib/postgres_to_redshift/key.rb
@@ -2,8 +2,8 @@ module PostgresToRedshift
   class Key
     PRIMARY_KEY = 'p'.freeze
     FOREIGN_KEY = 'f'.freeze
-    PRIMARY_KEY_DECOMPOSER = /PRIMARY KEY \((?<source_column_name>\w+)\)/i
-    FOREIGN_KEY_DECOMPOSER = /FOREIGN KEY \((?<source_column_name>\w+)\) REFERENCES (?<target_table_name>\w+)\((?<target_column_name>\w+)\)/i
+    PRIMARY_KEY_DECOMPOSER = /PRIMARY KEY \((?<source_column_name>\w+)\)/i.freeze
+    FOREIGN_KEY_DECOMPOSER = /FOREIGN KEY \((?<source_column_name>\w+)\) REFERENCES (?<target_table_name>\w+)\((?<target_column_name>\w+)\)/i.freeze
 
     def initialize(attributes:)
       @attributes = attributes
@@ -38,6 +38,14 @@ module PostgresToRedshift
       return if primary?
 
       decomposed_key[:target_column_name]
+    end
+
+    def touches_table?(name)
+      [target_table_name, table_name].compact.map(&:downcase).include?(name.downcase)
+    end
+
+    def key_name
+      attributes['name']
     end
 
     private
@@ -75,10 +83,6 @@ module PostgresToRedshift
 
     def table_name
       attributes['table_name']
-    end
-
-    def key_name
-      attributes['name']
     end
   end
 end

--- a/lib/postgres_to_redshift/version.rb
+++ b/lib/postgres_to_redshift/version.rb
@@ -1,3 +1,3 @@
 module PostgresToRedshift
-  VERSION = '0.7.0'.freeze
+  VERSION = '0.7.1'.freeze
 end


### PR DESCRIPTION
Incremental import will drop/create any tables in the source database whose schema has diverged from the target database. In order to ensure the target database performance, the keys for these dirty tables should be recreated in this situation.

https://cleo.atlassian.net/browse/PLAT-61