### PR TITLE
Support postgrers interval columns

### DIFF
--- a/lib/postgres_to_redshift/column.rb
+++ b/lib/postgres_to_redshift/column.rb
@@ -12,7 +12,8 @@ module PostgresToRedshift
       'oid' => 'CHARACTER VARYING(65535)',
       'ARRAY' => 'CHARACTER VARYING(65535)',
       'USER-DEFINED' => 'CHARACTER VARYING(65535)',
-      'uuid' => 'CHARACTER VARYING(36)'
+      'uuid' => 'CHARACTER VARYING(36)',
+      'interval' => 'CHARACTER VARYING(65535)'
     }.freeze
 
     def initialize(attributes:)

--- a/spec/lib/postgres_to_redshift/column_spec.rb
+++ b/spec/lib/postgres_to_redshift/column_spec.rb
@@ -147,6 +147,22 @@ RSpec.describe PostgresToRedshift::Column do
       expect(column.data_type_for_copy).to eq('CHARACTER VARYING(65535)')
     end
 
+    it 'casts interval to character varying(65535)' do
+      attributes = {
+        'table_catalog' => 'postgres_to_redshift',
+        'table_schema' => 'public',
+        'table_name' => 'films',
+        'column_name' => 'description',
+        'ordinal_position' => '2',
+        'column_default' => nil,
+        'is_nullable' => 'YES',
+        'data_type' => 'interval'
+      }
+
+      column = PostgresToRedshift::Column.new attributes: attributes
+      expect(column.data_type_for_copy).to eq('CHARACTER VARYING(65535)')
+    end
+
     it 'returns the data type if no cast necessary' do
       attributes = {
         'table_catalog' => 'postgres_to_redshift',


### PR DESCRIPTION
Unfortunately redshift understands interval literals, but not intervals as
types for columns (see: https://docs.aws.amazon.com/redshift/latest/dg/r_interval_literals.html)

Happily, we can treat them like strings (like we do with everything else
esoteric).