### PR TITLE
Use aws sdk v2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    postgres_to_redshift (0.7.2)
+    postgres_to_redshift (0.7.3)
       aws-sdk (~> 2.11)
       pg (>= 0.18.1)
       pidfile

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,8 @@
 PATH
   remote: .
   specs:
-    postgres_to_redshift (0.7.1)
-      aws-sdk-v1 (~> 1.54)
+    postgres_to_redshift (0.7.2)
+      aws-sdk (~> 2.11)
       pg (>= 0.18.1)
       pidfile
 
@@ -10,21 +10,25 @@ GEM
   remote: https://rubygems.org/
   specs:
     ast (2.4.0)
-    aws-sdk-v1 (1.67.0)
-      json (~> 1.4)
-      nokogiri (~> 1)
+    aws-eventstream (1.1.0)
+    aws-sdk (2.11.553)
+      aws-sdk-resources (= 2.11.553)
+    aws-sdk-core (2.11.553)
+      aws-sigv4 (~> 1.0)
+      jmespath (~> 1.0)
+    aws-sdk-resources (2.11.553)
+      aws-sdk-core (= 2.11.553)
+    aws-sigv4 (1.2.1)
+      aws-eventstream (~> 1, >= 1.0.2)
     coderay (1.1.2)
     diff-lcs (1.2.5)
     jaro_winkler (1.5.2)
-    json (1.8.6)
+    jmespath (1.4.0)
     method_source (0.9.2)
-    mini_portile2 (2.4.0)
-    nokogiri (1.10.7)
-      mini_portile2 (~> 2.4.0)
     parallel (1.15.0)
     parser (2.6.2.0)
       ast (~> 2.4.0)
-    pg (1.2.1)
+    pg (1.2.3)
     pidfile (0.3.0)
     pry (0.12.2)
       coderay (~> 1.1.0)

--- a/lib/postgres_to_redshift.rb
+++ b/lib/postgres_to_redshift.rb
@@ -1,4 +1,4 @@
-require 'aws-sdk-v1'
+require 'aws-sdk'
 require 'pg'
 require 'pidfile'
 require 'tempfile'
@@ -52,7 +52,7 @@ module PostgresToRedshift
   end
 
   def s3
-    @s3 ||= AWS::S3.new(access_key_id: ENV.fetch('S3_DATABASE_EXPORT_ID'), secret_access_key: ENV.fetch('S3_DATABASE_EXPORT_KEY'))
+    @s3 ||= Aws::S3.new(access_key_id: ENV.fetch('S3_DATABASE_EXPORT_ID'), secret_access_key: ENV.fetch('S3_DATABASE_EXPORT_KEY'))
   end
 
   def bucket

--- a/lib/postgres_to_redshift/version.rb
+++ b/lib/postgres_to_redshift/version.rb
@@ -1,3 +1,3 @@
 module PostgresToRedshift
-  VERSION = '0.7.2'.freeze
+  VERSION = '0.7.3'.freeze
 end

--- a/postgres_to_redshift.gemspec
+++ b/postgres_to_redshift.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'pry', '~> 0.12.2'
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rubocop', '~> 0.66'
-  spec.add_dependency 'aws-sdk-v1', '~> 1.54'
+  spec.add_dependency 'aws-sdk', '~> 2.11'
   spec.add_dependency 'pg', '>= 0.18.1'
   spec.add_dependency 'pidfile'
 end


### PR DESCRIPTION
This removes the dependency on the json gem which is convenient because
the json gem just had a [security advisory][advisory] published against
it which we'd like to avoid.  We couldn't in our main app because it uses
this gem and this gem used aws-sdk-v1 which relied on an old json.

[advisory]: https://github.com/advisories/GHSA-jphg-qwrw-7w9g